### PR TITLE
go backend: add pprof endpoints for debugging

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -4,6 +4,7 @@ import "github.com/alecthomas/kong"
 
 type Config struct {
 	ListenAddr      string `env:"LISTEN_ADDR" default:":8080"`
+	PprofAddr       string `env:"PPROF_ADDR" default:":8081"`
 	ClientID        string `env:"CLIENT_ID"`
 	ClientSecret    string `env:"CLIENT_SECRET"`
 	OwnerUserID     string `env:"OWNER_USER_ID"`


### PR DESCRIPTION
This should allow us to easily get profiles in the future when any unwanted behavior is occuring.

This should be safe to add as it is registered on to a separate port from any of the existing actual APIs or metrics.

---

Tested this locally to verify I can access the pprof routes and it does not impact the main port.

![image](https://github.com/user-attachments/assets/01c54494-a2a3-4878-9091-9b6199af988a)
